### PR TITLE
$ to \s error fix

### DIFF
--- a/spec/bundler_spec.rb
+++ b/spec/bundler_spec.rb
@@ -24,7 +24,7 @@ describe "Bundler" do
 
     # http://bundler.io/v1.3/gemfile.html
     it "should list the hashie gem without specifying a version" do
-      expect(@gemfile_text =~ /gem ['"]hashie['"]$/).not_to eq(nil)
+      expect(@gemfile_text =~ /gem ['"]hashie['"]\s/).not_to eq(nil)
     end
 
     # http://bundler.io/v1.3/gemfile.html


### PR DESCRIPTION
It creates an error with /n. `gem 'hashie'` won't pass respec unless at the end of the Gemfile due to $ behavior.  \s solves this issue.